### PR TITLE
feature(deps): 升级 springboot 4.0.0

### DIFF
--- a/annotation-meta/src/main/java/com/wuxp/codegen/meta/annotations/factories/AbstractAnnotationMate.java
+++ b/annotation-meta/src/main/java/com/wuxp/codegen/meta/annotations/factories/AbstractAnnotationMate.java
@@ -3,7 +3,8 @@ package com.wuxp.codegen.meta.annotations.factories;
 import com.wuxp.codegen.meta.util.CodegenAnnotationUtils;
 import com.wuxp.codegen.model.CommonCodeGenAnnotation;
 import lombok.Getter;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
+
 
 import java.lang.annotation.ElementType;
 import java.lang.reflect.Field;

--- a/annotation-meta/src/main/java/com/wuxp/codegen/meta/annotations/factories/spring/RequestMappingMetaFactory.java
+++ b/annotation-meta/src/main/java/com/wuxp/codegen/meta/annotations/factories/spring/RequestMappingMetaFactory.java
@@ -13,7 +13,7 @@ import com.wuxp.codegen.meta.util.RequestMappingUtils;
 import com.wuxp.codegen.model.CommonCodeGenAnnotation;
 import com.wuxp.codegen.model.constant.MappingAnnotationPropNameConstant;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.lang.NonNull;
+import org.jspecify.annotations.NonNull;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.Assert;
 import org.springframework.util.PathMatcher;

--- a/annotation-meta/src/main/java/com/wuxp/codegen/meta/transform/spring/SpringRequestMappingTransformer.java
+++ b/annotation-meta/src/main/java/com/wuxp/codegen/meta/transform/spring/SpringRequestMappingTransformer.java
@@ -64,7 +64,6 @@ public class SpringRequestMappingTransformer implements
         mediaTypeMapping.put(MediaType.MULTIPART_FORM_DATA_VALUE, "MediaType.MULTIPART_FORM_DATA_VALUE");
         mediaTypeMapping.put(MediaType.APPLICATION_FORM_URLENCODED_VALUE, "MediaType.APPLICATION_FORM_URLENCODED_VALUE");
         mediaTypeMapping.put(MediaType.APPLICATION_JSON_VALUE, "MediaType.APPLICATION_JSON_VALUE");
-        mediaTypeMapping.put(MediaType.APPLICATION_JSON_UTF8_VALUE, "MediaType.APPLICATION_JSON_UTF8_VALUE");
         mediaTypeMapping.put(MediaType.APPLICATION_OCTET_STREAM_VALUE, "MediaType.APPLICATION_OCTET_STREAM_VALUE");
     }
 

--- a/annotation-meta/src/main/java/com/wuxp/codegen/meta/transform/spring/TypeScriptRequestMappingTransformer.java
+++ b/annotation-meta/src/main/java/com/wuxp/codegen/meta/transform/spring/TypeScriptRequestMappingTransformer.java
@@ -32,7 +32,6 @@ public class TypeScriptRequestMappingTransformer extends SpringRequestMappingTra
         mediaTypeMapping.put(MediaType.MULTIPART_FORM_DATA_VALUE, TypescriptFeignMediaTypeConstant.MULTIPART_FORM_DATA);
         mediaTypeMapping.put(MediaType.APPLICATION_FORM_URLENCODED_VALUE, TypescriptFeignMediaTypeConstant.FORM_DATA);
         mediaTypeMapping.put(MediaType.APPLICATION_JSON_VALUE, TypescriptFeignMediaTypeConstant.APPLICATION_JSON);
-        mediaTypeMapping.put(MediaType.APPLICATION_JSON_UTF8_VALUE, TypescriptFeignMediaTypeConstant.APPLICATION_JSON_UTF8);
         mediaTypeMapping.put(MediaType.APPLICATION_OCTET_STREAM_VALUE, TypescriptFeignMediaTypeConstant.APPLICATION_OCTET_STREAM);
     }
 

--- a/annotation-meta/src/main/java/com/wuxp/codegen/meta/util/CodegenAnnotationUtils.java
+++ b/annotation-meta/src/main/java/com/wuxp/codegen/meta/util/CodegenAnnotationUtils.java
@@ -3,7 +3,7 @@ package com.wuxp.codegen.meta.util;
 import com.wuxp.codegen.model.util.JavaTypeUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.annotation.MergedAnnotation;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 

--- a/core/src/main/java/com/wuxp/codegen/core/CodegenVersion.java
+++ b/core/src/main/java/com/wuxp/codegen/core/CodegenVersion.java
@@ -11,5 +11,5 @@ public final class CodegenVersion {
     /**
      * 项目版本号
      */
-    public static final String VERSION = "1.0.2-jdk21-SNAPSHOT";
+    public static final String VERSION = "1.1.0-jdk21-SNAPSHOT";
 }

--- a/core/src/main/java/com/wuxp/codegen/core/parser/LanguageElementDefinitionParser.java
+++ b/core/src/main/java/com/wuxp/codegen/core/parser/LanguageElementDefinitionParser.java
@@ -3,7 +3,7 @@ package com.wuxp.codegen.core.parser;
 import com.wuxp.codegen.core.CodeGenClassSupportHandler;
 import com.wuxp.codegen.model.CommonBaseMeta;
 import com.wuxp.codegen.model.CommonCodeGenClassMeta;
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Type;
 import java.util.List;

--- a/examples/swagger-2/src/main/java/com/wuxp/codegen/swagger2/example/Swagger2.java
+++ b/examples/swagger-2/src/main/java/com/wuxp/codegen/swagger2/example/Swagger2.java
@@ -3,7 +3,7 @@ package com.wuxp.codegen.swagger2.example;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -51,7 +51,7 @@ public class Swagger2 implements WebMvcConfigurer {
                 objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
                 objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
                 //设置下划线转换
-                objectMapper.setPropertyNamingStrategy(new PropertyNamingStrategy.SnakeCaseStrategy());
+                objectMapper.setPropertyNamingStrategy(new PropertyNamingStrategies.SnakeCaseStrategy());
             }
         }
     }

--- a/examples/swagger-2/src/main/java/com/wuxp/codegen/swagger2/example/domain/Order.java
+++ b/examples/swagger-2/src/main/java/com/wuxp/codegen/swagger2/example/domain/Order.java
@@ -1,16 +1,18 @@
 package com.wuxp.codegen.swagger2.example.domain;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.Date;
 
+@EqualsAndHashCode(callSuper = true)
 @ApiModel("订单")
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Order extends BaseInfo<Long> {
 
     @ApiModelProperty(value = "sn", example = "order_sn_199223")

--- a/examples/swagger-3-maven-plugin/pom.xml
+++ b/examples/swagger-3-maven-plugin/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>com.wuxp.codegen</groupId>
                 <artifactId>wuxp-codegen-loong-maven-plugin</artifactId>
-                <version>${project.version}</version>
+                <version>${revision}</version>
                 <configuration>
                     <skip>false</skip>
                     <projectName>swagger-3-example-maven-plugin</projectName>

--- a/examples/swagger-3-maven-plugin/src/main/java/com/wuxp/codegen/swagger3/example/maven/domain/Order.java
+++ b/examples/swagger-3-maven-plugin/src/main/java/com/wuxp/codegen/swagger3/example/maven/domain/Order.java
@@ -1,15 +1,17 @@
 package com.wuxp.codegen.swagger3.example.maven.domain;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.Date;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Order extends BaseInfo<Long, String> {
 
     @Parameter()

--- a/examples/swagger-3/src/main/java/com/wuxp/codegen/swagger3/example/domain/Order.java
+++ b/examples/swagger-3/src/main/java/com/wuxp/codegen/swagger3/example/domain/Order.java
@@ -1,15 +1,18 @@
 package com.wuxp.codegen.swagger3.example.domain;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.Date;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
-@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class Order extends BaseInfo<Long, String> {
 
     @Parameter()

--- a/languages/src/main/java/com/wuxp/codegen/languages/AbstractLanguageFieldDefinitionParser.java
+++ b/languages/src/main/java/com/wuxp/codegen/languages/AbstractLanguageFieldDefinitionParser.java
@@ -7,7 +7,7 @@ import com.wuxp.codegen.model.CommonCodeGenClassMeta;
 import com.wuxp.codegen.model.CommonCodeGenFiledMeta;
 import com.wuxp.codegen.model.languages.java.JavaFieldMeta;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.lang.NonNull;
+import org.jspecify.annotations.NonNull;
 import org.springframework.util.ObjectUtils;
 
 import jakarta.validation.constraints.NotBlank;

--- a/languages/src/main/java/com/wuxp/codegen/languages/typescript/UmiRequestMethodDefinitionPostProcessor.java
+++ b/languages/src/main/java/com/wuxp/codegen/languages/typescript/UmiRequestMethodDefinitionPostProcessor.java
@@ -188,21 +188,13 @@ public class UmiRequestMethodDefinitionPostProcessor implements LanguageDefiniti
     }
 
     private String getContentTypeAlisName(String contentType) {
-        switch (contentType) {
-            case MediaType.APPLICATION_FORM_URLENCODED_VALUE:
-            case MediaType.MULTIPART_FORM_DATA_VALUE:
-                return "form";
-            case MediaType.TEXT_HTML_VALUE:
-            case MediaType.TEXT_PLAIN_VALUE:
-                return "text";
-            case MediaType.APPLICATION_OCTET_STREAM_VALUE:
-                return "blob";
-            case MediaType.APPLICATION_JSON_VALUE:
-            case MediaType.APPLICATION_PROBLEM_JSON_UTF8_VALUE:
-                return "json";
-            default:
-                return null;
-        }
+        return switch (contentType) {
+            case MediaType.APPLICATION_FORM_URLENCODED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE -> "form";
+            case MediaType.TEXT_HTML_VALUE, MediaType.TEXT_PLAIN_VALUE -> "text";
+            case MediaType.APPLICATION_OCTET_STREAM_VALUE -> "blob";
+            case MediaType.APPLICATION_JSON_VALUE -> "json";
+            default -> null;
+        };
     }
 
     private boolean hasRequestBody(JavaMethodMeta javaMethodMeta) {

--- a/loong-quick/codegen-server/pom.xml
+++ b/loong-quick/codegen-server/pom.xml
@@ -43,7 +43,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-aop</artifactId>
+            <artifactId>spring-boot-starter-aspectj</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -119,6 +119,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/loong-quick/codegen-server/src/main/java/com/wuxp/codegen/server/LoongCodegenApplication.java
+++ b/loong-quick/codegen-server/src/main/java/com/wuxp/codegen/server/LoongCodegenApplication.java
@@ -4,7 +4,7 @@ package com.wuxp.codegen.server;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 

--- a/loong-quick/codegen-server/src/main/java/com/wuxp/codegen/server/task/CodegenTaskService.java
+++ b/loong-quick/codegen-server/src/main/java/com/wuxp/codegen/server/task/CodegenTaskService.java
@@ -1,7 +1,7 @@
 package com.wuxp.codegen.server.task;
 
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * 代码生成任务服务

--- a/loong-quick/codegen-server/src/main/java/com/wuxp/codegen/server/vcs/SourceCodeRepositoryAccessProperties.java
+++ b/loong-quick/codegen-server/src/main/java/com/wuxp/codegen/server/vcs/SourceCodeRepositoryAccessProperties.java
@@ -2,8 +2,9 @@ package com.wuxp.codegen.server.vcs;
 
 
 import com.wuxp.codegen.server.enums.SourcecodeRepositoryType;
+import org.jspecify.annotations.Nullable;
 import org.springframework.core.Ordered;
-import org.springframework.lang.Nullable;
+
 
 
 /**

--- a/loong-quick/codegen-server/src/test/java/com/wuxp/codegen/server/repositories/SourceCodeRepositoryRepositoryTests.java
+++ b/loong-quick/codegen-server/src/test/java/com/wuxp/codegen/server/repositories/SourceCodeRepositoryRepositoryTests.java
@@ -4,14 +4,16 @@ import com.wuxp.codegen.server.entities.CodeVersionControlConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 
 import java.util.List;
 
-@Import(CodegenJpaAuditorAwareConfig.class)
-@DataJpaTest
+@ContextConfiguration(classes = {CodegenJpaAuditorAwareConfig.class})
+@EnableJpaRepositories(basePackages = {"com.wuxp.codegen.server.repositories"})
+@EntityScan("com.wuxp.codegen.server.entities")
 @ActiveProfiles("test")
 class SourceCodeRepositoryRepositoryTests {
 

--- a/loong-quick/codegen-server/src/test/java/com/wuxp/codegen/server/task/SourceCodeManagerTaskServiceTest.java
+++ b/loong-quick/codegen-server/src/test/java/com/wuxp/codegen/server/task/SourceCodeManagerTaskServiceTest.java
@@ -9,9 +9,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -26,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import static com.wuxp.codegen.server.constant.VcsConstants.DEFAULT_REPOSITORY_NANE;
 
 
-@DataJpaTest(properties = {"spring.profiles.active=test"})
 @ContextConfiguration(classes = {SourceCodeManagerTaskServiceTest.TaskConfig.class, LoongCodegenProperties.class, LoongCodegenConfig.class})
 @EnableJpaRepositories(basePackages = {"com.wuxp.codegen.server.repositories"})
 @EntityScan("com.wuxp.codegen.server.entities")

--- a/loong-quick/codegen-server/src/test/java/com/wuxp/codegen/server/vcs/JGitSourcecodeRepositoryTest.java
+++ b/loong-quick/codegen-server/src/test/java/com/wuxp/codegen/server/vcs/JGitSourcecodeRepositoryTest.java
@@ -4,10 +4,10 @@ import com.wuxp.codegen.server.config.LoongCodegenProperties;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import java.util.Collections;
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.when;
 @ConfigurationPropertiesScan("com.wuxp.codegen")
 class JGitSourcecodeRepositoryTest {
 
-    @MockBean
+    @MockitoBean
     private SourcecodeRepository sourcecodeRepository;
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.wind.middleware</groupId>
         <artifactId>wind-middleware</artifactId>
-        <version>1.0.2-jdk21-SNAPSHOT</version>
+        <version>1.1.0-jdk21-SNAPSHOT</version>
         <!-- lookup parent from repository -->
         <relativePath/>
     </parent>
@@ -37,7 +37,7 @@
     </modules>
 
     <properties>
-        <revision>1.0.2-jdk21-SNAPSHOT</revision>
+        <revision>1.1.0-jdk21-SNAPSHOT</revision>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <jdk.version>${maven.compiler.target}</jdk.version>


### PR DESCRIPTION
- 将 Nullable 注解从 Spring 的包替换为 jspecify 包
- 更新 NonNull 注解引用路径
- 升级 Jackson 属性命名策略类引用
- 移除已废弃的 APPLICATION_JSON_UTF8_VALUE 媒体类型
- 使用新的 MockitoBean 替换 MockBean
- 更新 Maven 插件版本占位符为 revision
- 升级 Spring Boot AOP starter 为 aspectj starter
- 优化 switch 表达式语法提高可读性
- 添加 EqualsAndHashCode 注解增强对象比较能力
- 更新父项目及项目版本号至 1.1.0-jdk21-SNAPSHOT